### PR TITLE
Reload browser if displaying form and $GLOBALS['it_exchange']['product'] is not set.

### DIFF
--- a/lib/templates/super-widget-gravity-forms-checkout-info.php
+++ b/lib/templates/super-widget-gravity-forms-checkout-info.php
@@ -20,6 +20,14 @@ if ( in_array( 'logged-in', it_exchange_get_pending_purchase_requirements() ) )
 $session_data = it_exchange_get_session_data( 'ibd_gfci_checkout_forms' );
 $id = $GLOBALS['it_exchange']['product']->ID;
 
+if (empty($id)) {
+	?>
+	<script>
+		location.reload();
+	</script>
+	<?php
+}
+
 if ( !it_exchange_product_has_feature( $id, 'ibd-gravity-forms-info' ) || isset( $session_data[$id] ) )
 	return;
 


### PR DESCRIPTION
Another issue that I ran into is a blank super-widget when a form needs to be displayed immediately after a user registers in the ajax super-widget.

**To reproduce:**
1. add product to cart while logged out
2. click checkout and register a new account
3. see a blank super-widget and have to refresh to complete checkout

When inspecting this file I noticed that the `$GLOBALS` variable does not have the `['it_exchange']['product']` data in it unless the user is logged in when the checkout process starts.

I imagine there is likely a better way to get this data within the AJAX request, but for now I used a JS refresh of the page so the user can click "checkout" a second time and see the form (because `$GLOBALS['it_exchange']['product']` is full of info).
